### PR TITLE
fix #2960

### DIFF
--- a/app/web/components/lesson/common/PackageBasicDetail.vue
+++ b/app/web/components/lesson/common/PackageBasicDetail.vue
@@ -63,12 +63,10 @@ export default {
           this.isLogin = false
         })
     }
-    if (
-      this.isTeacher &&
-      this.isPendingReview &&
-      !this.isOwnPackage
-    ) {
-      this.$router.push({ name: 'StudentCenter' })
+    if (this.isPendingReview) {
+      if (!this.isOwnPackage || !this.isTeacher) {
+        this.$router.push({ name: 'StudentCenter' })
+      }
     }
   },
   computed: {
@@ -86,7 +84,7 @@ export default {
       return this.actorType === 'teacher'
     },
     loginUserId() {
-      return _.get(this.userProfile, '_id')
+      return _.get(this.userProfile, 'id')
     },
     packageOwnerId() {
       return _.get(this.packageDetail, 'userId')

--- a/app/web/components/lesson/common/PackageCatalogue.vue
+++ b/app/web/components/lesson/common/PackageCatalogue.vue
@@ -56,7 +56,7 @@ export default {
       isBeInClassroom: 'lesson/student/isBeInClassroom'
     }),
     loginUserId() {
-      return _.get(this.userProfile, '_id')
+      return _.get(this.userProfile, 'id')
     },
     packageOwnerId() {
       return _.get(this.packageDetail, 'userId')

--- a/app/web/components/pbl/NewProject.vue
+++ b/app/web/components/pbl/NewProject.vue
@@ -5,7 +5,7 @@
       <p class="new-project-info">项目，是一个作品的开始。<br>它将让你在学习中成长，让你体会到团结协作的快乐，让你成为优秀的管理者！</p>
       <div class="new-project-name">
         <label for="projectName" class="new-project-label">项目名称</label>
-        <el-input id="projectName" v-model="newProjectData.name" @blur='checkProjectName'></el-input>
+        <el-input id="projectName" maxlength="40" v-model="newProjectData.name" @blur='checkProjectName'></el-input>
       </div>
       <div class="new-project-type">
         <label for="projectName" class="new-project-label">项目类型</label>

--- a/app/web/components/pbl/common/ProjectBasicInfo.vue
+++ b/app/web/components/pbl/common/ProjectBasicInfo.vue
@@ -662,6 +662,10 @@ export default {
     .w-e-text {
       padding: 0 8px;
     }
+    &-editor {
+      position: relative;
+      z-index: 1;
+    }
   }
   &-apply-dialog {
     .el-dialog__header {

--- a/app/web/components/pbl/common/ProjectBoards.vue
+++ b/app/web/components/pbl/common/ProjectBoards.vue
@@ -149,5 +149,8 @@ export default {
       color: #63e08f;
     }
   }
+  &-empty {
+    font-size: 14px;
+  }
 }
 </style>


### PR DESCRIPTION
- fix 用户id获取不到，导致无法访问自己的课程详情页
- fix 新建paracraft项目的名称最大不超过40
- fix 项目详情页的富文本层级bug
- fix 项目详情页白板为空时字体的大小，调整为14px